### PR TITLE
Change from 'exit' to 'close' event

### DIFF
--- a/lib/ffprobe.js
+++ b/lib/ffprobe.js
@@ -88,7 +88,7 @@ module.exports = (function() {
 
 		proc.stdout.on('data', function(data) { probeData.push(data) });
 
-		proc.on('exit', function() {
+		proc.on('close', function() {
 			var blocks = findBlocks(probeData.join(''));
 
 			var s = parseStreams(blocks.streams),


### PR DESCRIPTION
Upgrading from 0.6 to 0.8, the `exit` event was firing without the `data` event ever firing -- not an issue when reading probing one file in the REPL, but would cause the `stream`, `format` and `metadata` to be undefined or null. Nice library, thanks!
