### PR TITLE
Three fixes

### DIFF
--- a/lib/ffprobe.js
+++ b/lib/ffprobe.js
@@ -1,4 +1,5 @@
 var spawn = require('child_process').spawn,
+		fs = require('fs'),
 		path = require('path');
 
 module.exports = (function() {


### PR DESCRIPTION
- Data can come in from a child process after exit; the close event
  was added to handle this case, so use it.
- The findBlocks function was adding 8 to the indexOf calls, and then
  checking against -1 instead of -1 + 8.
- To use fs.exists instead of path.exists, you need to require fs.
