### PR TITLE
allow ffprobe on non-local files

### DIFF
--- a/lib/ffprobe.js
+++ b/lib/ffprobe.js
@@ -81,19 +81,31 @@ module.exports = (function() {
 	};
 
 	function doProbe(file, callback) {
-		var proc = spawn('ffprobe', ['-show_streams', '-show_format', file]),
+		var proc = spawn('ffprobe', ['-show_streams', '-show_format', '-loglevel', 'warning', file]),
 				probeData = [],
+				errData = [],
+				exitCode = null,
 				start = Date.now();
 
 		proc.stdout.setEncoding('utf8');
+		proc.stderr.setEncoding('utf8');
 
 		proc.stdout.on('data', function(data) { probeData.push(data) });
+		proc.stderr.on('data', function(data) { errData.push(data) });
 
+		proc.on('exit', function(code) {
+			exitCode = code;
+		});
 		proc.on('close', function() {
 			var blocks = findBlocks(probeData.join(''));
 
 			var s = parseStreams(blocks.streams),
 					f = parseFormat(blocks.format);
+
+			if (exitCode) {
+				var err_output = errData.join('');
+				callback(err_output);
+			}
 
 			callback(null, {
 				filename: path.basename(file),


### PR DESCRIPTION
I was hoping to use node-ffprobe for some HTTP-hosted files (as opposed to files stored locally), but there's a `fs.exists` check before the process is spawned.

The first commit here removes that check, and the second commit obtains the exit status of the ffprobe process. If it's non-zero, the resulting error uses the process' stderr output.

A simple test script, along with the before/after output (with both existing and absent files), can be found [here](https://gist.github.com/3824670). Let me know if there's anything I can do.
