### PR TITLE
doProbe completion callback gets called twice on error.

### DIFF
--- a/lib/ffprobe.js
+++ b/lib/ffprobe.js
@@ -104,7 +104,7 @@ module.exports = (function() {
 
 			if (exitCode) {
 				var err_output = errData.join('');
-				callback(err_output);
+				return callback(err_output);
 			}
 
 			callback(null, {


### PR DESCRIPTION
If there's an exit code, it's probably safe to assume nothing valid
coming out of ffprobe. If we don't return on the error callback, it
attempts to callback a second time with (probably empty) probe data.
