### PR TITLE
Add error handler

### DIFF
--- a/lib/ffprobe.js
+++ b/lib/ffprobe.js
@@ -85,6 +85,7 @@ module.exports = (function() {
 				probeData = [],
 				errData = [],
 				exitCode = null,
+				error = null,
 				start = Date.now();
 
 		proc.stdout.setEncoding('utf8');
@@ -95,6 +96,9 @@ module.exports = (function() {
 
 		proc.on('exit', function(code) {
 			exitCode = code;
+		});
+		proc.on('error', function(err) {
+			callback(err);
 		});
 		proc.on('close', function() {
 			var blocks = findBlocks(probeData.join(''));


### PR DESCRIPTION
Add 'error' event handler on spawned process; this allows for example catching the absence of the ffprobe executable.
