### PR TITLE
Handle process errors

### DIFF
--- a/lib/ffprobe.js
+++ b/lib/ffprobe.js
@@ -96,6 +96,9 @@ module.exports = (function() {
 		proc.on('exit', function(code) {
 			exitCode = code;
 		});
+		proc.on('error', function(err) {
+			callback(err);
+		});
 		proc.on('close', function() {
 			var blocks = findBlocks(probeData.join(''));
 


### PR DESCRIPTION
This change enables handling child process creation errors and pushes them
back to the user callback.  Such errors can happen for example when ffprobe
is not present, when the user does not have execution rights on it, etc.
