### PR TITLE
Also extract metadata from streams

### DIFF
--- a/lib/ffprobe.js
+++ b/lib/ffprobe.js
@@ -41,10 +41,20 @@ module.exports = (function() {
 		return block_object;
 	};
 
+	function extractMetadata(raw_data, metadata, other) {
+		for(var attr in raw_data) {
+			if(raw_data.hasOwnProperty(attr)) {
+				if(attr.indexOf('TAG') === -1) other[attr] = raw_data[attr];
+				else metadata[attr.slice(4)] = raw_data[attr];
+			}
+		}
+	}
+
 	function parseStreams(text, callback) {
 		if(!text) return { streams: null };
 
 		var streams = [];
+		var streamsMetadata = [];
 		var blocks = text.replace('[STREAM]\n', '').split('[/STREAM]');
 
 		blocks.forEach(function(stream, idx) {
@@ -52,11 +62,22 @@ module.exports = (function() {
 			var sindex = codec_data.index;
 			delete codec_data.index;
 
-			if(sindex) streams[sindex] = codec_data;
-			else streams.push(codec_data);
+			var stream = { },
+					metadata = { };
+
+			extractMetadata(codec_data, metadata, stream);
+
+			if(sindex) {
+				streams[sindex] = stream;
+				streamsMetadata[sindex] = metadata;
+			}
+			else {
+				streams.push(codec_data);
+				streamsMetadata.push(metadata);
+			}
 		});
 
-		return { streams: streams };
+		return { streams: streams, metadata: streamsMetadata };
 	};
 
 	function parseFormat(text, callback) {
@@ -70,12 +91,7 @@ module.exports = (function() {
 
 		//REMOVE metadata
 		delete raw_format.filename;
-		for(var attr in raw_format) {
-			if(raw_format.hasOwnProperty(attr)) {
-				if(attr.indexOf('TAG') === -1) format[attr] = raw_format[attr];
-				else metadata[attr.slice(4)] = raw_format[attr];
-			}
-		}
+		extractMetadata(raw_format, metadata, format);
 
 		return { format: format, metadata: metadata };
 	};
@@ -106,6 +122,8 @@ module.exports = (function() {
 				var err_output = errData.join('');
 				return callback(err_output);
 			}
+
+			f.metadata.streams = s.metadata;
 
 			callback(null, {
 				filename: path.basename(file),


### PR DESCRIPTION
Some formats have metadata in STREAM blocks (eg. sometimes an Ogg Vorbis file
has no metadata in the Ogg container, but the Vorbis stream has some).
This change extacts metadata from streams and adds them as "streams" in
the returned metadata.  It does not overwrite metadata from the FORMAT block,
so that users can decide if they prefer format metadata or stream metadata
when both are present.
