### PR TITLE
library path

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Usage
 ----------
 
 ```js
-var probe = require('node-ffprobe');
+var probe = require('node-ffprobe')('/path/to/binary/');
 
 var track = '/path/to/media/file.mp3';
 
@@ -23,6 +23,7 @@ probe(track, function(err, probeData) {
 	console.log(probeData);
 });
 ```
+The '/path/to/binary/' is useful if you embed the lib in your app. Otherwise just leave it ''.
 
 Calling probe will execute ffprobe and parse the data it sends to STDOUT.  A sample object can be seen below.
 

--- a/README.md
+++ b/README.md
@@ -15,15 +15,15 @@ Usage
 ----------
 
 ```js
-var probe = require('node-ffprobe')('/path/to/binary/');
-
+var probe = require('node-ffprobe');
+probe.FFPROBE_PATH = '/path/to/ffprobe'; //optional
 var track = '/path/to/media/file.mp3';
 
 probe(track, function(err, probeData) {
 	console.log(probeData);
 });
 ```
-The '/path/to/binary/' is useful if you embed the lib in your app. Otherwise just leave it ''.
+FFPROBE_PATH is useful if you embed the lib in your app.
 
 Calling probe will execute ffprobe and parse the data it sends to STDOUT.  A sample object can be seen below.
 

--- a/lib/ffprobe.js
+++ b/lib/ffprobe.js
@@ -2,7 +2,9 @@ var spawn = require('child_process').spawn,
 		fs = require('fs'),
 		path = require('path');
 
-module.exports = (function() {
+module.exports = function(appLibRoot) {
+	var probeRoot = typeof appLibRoot !== undefined ? appLibRoot : "";
+
 	function findBlocks(raw) {
 		var stream_start = raw.indexOf('[STREAM]') + 8,
 				stream_end = raw.lastIndexOf('[/STREAM]'),
@@ -81,7 +83,7 @@ module.exports = (function() {
 	};
 
 	function doProbe(file, callback) {
-		var proc = spawn('ffprobe', ['-show_streams', '-show_format', '-loglevel', 'warning', file]),
+		var proc = spawn(probeRoot + 'ffprobe', ['-show_streams', '-show_format', '-loglevel', 'warning', file]),
 				probeData = [],
 				errData = [],
 				exitCode = null,
@@ -121,4 +123,4 @@ module.exports = (function() {
 	};
 
 	return doProbe;
-})()
+}

--- a/lib/ffprobe.js
+++ b/lib/ffprobe.js
@@ -2,9 +2,7 @@ var spawn = require('child_process').spawn,
 		fs = require('fs'),
 		path = require('path');
 
-module.exports = function(appLibRoot) {
-	var probeRoot = typeof appLibRoot !== undefined ? appLibRoot : "";
-
+module.exports = (function() {
 	function findBlocks(raw) {
 		var stream_start = raw.indexOf('[STREAM]') + 8,
 				stream_end = raw.lastIndexOf('[/STREAM]'),
@@ -83,7 +81,7 @@ module.exports = function(appLibRoot) {
 	};
 
 	function doProbe(file, callback) {
-		var proc = spawn(probeRoot + 'ffprobe', ['-show_streams', '-show_format', '-loglevel', 'warning', file]),
+		var proc = spawn(module.exports.FFPROBE_PATH || 'ffprobe', ['-show_streams', '-show_format', '-loglevel', 'warning', file]),
 				probeData = [],
 				errData = [],
 				exitCode = null,
@@ -123,4 +121,4 @@ module.exports = function(appLibRoot) {
 	};
 
 	return doProbe;
-}
+})()

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-ffprobe",
-  "version": "1.2.2",
+  "version": "1.3",
   "description": "NodeJS wrapper around ffprobe",
   "keywords": ["ffprobe", "id3"],
   "repository": "git://github.com/ListenerApproved/node-ffprobe.git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-ffprobe",
-  "version": "1.3",
+  "version": "1.3.0",
   "description": "NodeJS wrapper around ffprobe",
   "keywords": ["ffprobe", "id3"],
   "repository": "git://github.com/ListenerApproved/node-ffprobe.git",


### PR DESCRIPTION
Hi,
I need to set the lib path for probe in my project, couse I need to embed that.
The bad of my changes here, is that is not guaranteed the back compatibility. 
You can't do anymore just:

``` js
require('node-ffprobe');
```

but you need:

``` js
require('node-ffprobe')();
```

I don't fully like it but I can't do better... if you have a better solution, it is welcome.
