### PR TITLE
File protection + optional synchronous launch for ffprobe

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 FFProbe for NodeJS
 ==========
 
-A simple wrapper around ffprobe written in NodeJS
+A simple sync wrapper around ffprobe written in NodeJS
 
 ***This module requires ffmpeg to be installed before it can function***.  The ffmpeg package comes bundled with ffprobe.
 
@@ -13,17 +13,10 @@ Installation
    
    ```js
      "dependencies": {
-   
         "node-ffprobe": "git+ssh://git@github.com:ListenerApproved/node-ffprobe.git#master",
-      
         "@ffprobe-installer/ffprobe": "^1.0.8"
-      
      }
    ```
-    
-    
-    
-
 
 Run
 ----------
@@ -50,6 +43,8 @@ probe(track, (err, probeData) => {
 FFPROBE_PATH is useful if you embed the lib in your app.
 
 Calling probe will execute ffprobe and parse the data it sends to STDOUT.  A sample object can be seen below.
+
+Additionnally, you can set `ffprobe.SYNC` to `true` if you want for a particular reason to launch ffprobe synchronously (for example when used in batch processing of files to avoid too many spawns at once.)
 
 The ***streams***, ***format***, and ***metadata*** fields are taken directly from ffprobe.
 ***probe_time*** is the total execution time for the given file.

--- a/index.js
+++ b/index.js
@@ -14,7 +14,7 @@ if(require.main === module) {
 
 	!function probeFile(file) {
 		if(!file) return exit(0, 'Finished probing all files');
-
+		file = '"'+file+'"';
 		ffprobe(file, function(err, results) {
 			console.log('%s\n========================================\n%s\n\n', file, err || JSON.stringify(results, null, '   '));
 

--- a/lib/ffprobe.js
+++ b/lib/ffprobe.js
@@ -1,5 +1,4 @@
 var spawn = require('child_process').spawn,
-		fs = require('fs'),
 		path = require('path');
 
 module.exports = (function() {

--- a/lib/ffprobe.js
+++ b/lib/ffprobe.js
@@ -1,5 +1,8 @@
 var spawn = require('child_process').spawn,
-		path = require('path');
+    spawnSync = require('child_process').spawnSync,
+	path = require('path');
+
+
 
 module.exports = (function() {
 	function findBlocks(raw) {
@@ -95,6 +98,37 @@ module.exports = (function() {
 		return { format: format, metadata: metadata };
 	};
 
+	function doProbeSync(file, callback) {
+		var proc = spawnSync(module.exports.FFPROBE_PATH || 'ffprobe', ['-show_streams', '-show_format', '-loglevel', 'warning', file], { encoding : 'utf8' }),
+				probeData = [],
+				errData = [],
+				exitCode = null,
+				start = Date.now();
+		probeData.push(proc.stdout);
+		errData.push(proc.stderr);
+		exitCode = proc.status;
+		if (proc.error) {
+			callback(proc.error); 
+		}
+		var blocks = findBlocks(probeData.join(''));
+		var s = parseStreams(blocks.streams),
+			f = parseFormat(blocks.format);
+		if (exitCode) {
+			var err_output = errData.join('');
+			return callback(err_output);
+		}
+		f.metadata.streams = s.metadata;
+		callback(null, {
+			filename: path.basename(file),
+			filepath: path.dirname(file),
+			fileext: path.extname(file),
+			file: file,
+			probe_time: Date.now() - start,
+			streams: s.streams,
+			format: f.format,
+			metadata: f.metadata
+		});		
+	}
 	function doProbe(file, callback) {
 		var proc = spawn(module.exports.FFPROBE_PATH || 'ffprobe', ['-show_streams', '-show_format', '-loglevel', 'warning', file]),
 
@@ -141,5 +175,6 @@ module.exports = (function() {
 		});
 	};
 
+	if (module.exports.SYNC) return doProbeSync;
 	return doProbe;
 })()


### PR DESCRIPTION
I've been using node-ffprobe for a while in [my project Karaoke Mugen](https://lab.shelter.moe/karaokemugen/karaokemugen-app/) and decided it was about time to contribute back. 

Since we're doing batch processing of video files, we need ffprobe to be run synchronously (or else the computer would be killed by the processes spawning on a large (5000+) video file folder.

Also, we ran into errors when the files contained spaces. Adding " " around made it work better.