### PR TITLE
Update Dependencies to be an Object

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,6 @@
   "author": "Thomas Quick <thomas@listenerapproved.com> (http://listenerapproved.com)",
   "main": "index",
   "contributors": [],
-  "dependencies": [],
+  "dependencies": {},
   "engines": { "node": ">= 0.6.0" }
 }


### PR DESCRIPTION
Ran into a super weird edge case involving an Electron application that had `node-ffprobe` as a transitive dependency.  Here is the electron-builder issue https://github.com/electron-userland/electron-builder/issues/3050

Dependencies as an array is invalid. Oddly enough this made an Electron application fail to build. Changing this to an empty object should fix the issue in case any one else runs into it.

Let me know if I got the wrong branch or something like that. Thanks for creating this package!