### PR TITLE
make index.js executable & a bin

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,3 +1,4 @@
+#!/usr/bin/env node
 const ffprobe = module.exports = require('./lib/ffprobe.js')
 
 if (require.main === module) {

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "node-ffprobe",
   "version": "3.0.0",
   "description": "NodeJS wrapper around ffprobe",
+  "bin": "./index.js",
   "keywords": [
     "ffprobe",
     "id3"


### PR DESCRIPTION
this is a helpful tool for understanding what output node-ffmpeg will issue.

first, make index.js directly executable by `chmod +x`'ing it and adding a shebang to have node be the interpetter.

second, add a "bin" in package.json so that that this utility is installed.